### PR TITLE
Add a gtest for target riscv64-unknown-linux-gnu-gcc

### DIFF
--- a/configure
+++ b/configure
@@ -126,7 +126,7 @@ all_platforms="${all_platforms} loongarch64-linux-gcc"
 all_platforms="${all_platforms} mips32-linux-gcc"
 all_platforms="${all_platforms} mips64-linux-gcc"
 all_platforms="${all_platforms} ppc64le-linux-gcc"
-all_platforms="${all_platforms} riscv64-unknown-linux-gnu"
+all_platforms="${all_platforms} riscv64-unknown-linux-gnu-gcc"
 all_platforms="${all_platforms} sparc-solaris-gcc"
 all_platforms="${all_platforms} x86-android-gcc"
 all_platforms="${all_platforms} x86-darwin8-gcc"
@@ -675,6 +675,11 @@ process_toolchain() {
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
         if enabled arm; then
           check_add_cxxflags -Wno-psabi
+        fi
+
+	if enabled riscv64; then
+	  check_add_cxxflags -march=rv64gcv
+	  check_add_cflags -march=rv64gcv
         fi
 
         # Enforce C++11 compatibility.

--- a/configure
+++ b/configure
@@ -126,6 +126,7 @@ all_platforms="${all_platforms} loongarch64-linux-gcc"
 all_platforms="${all_platforms} mips32-linux-gcc"
 all_platforms="${all_platforms} mips64-linux-gcc"
 all_platforms="${all_platforms} ppc64le-linux-gcc"
+all_platforms="${all_platforms} riscv64-unknown-linux-gnu"
 all_platforms="${all_platforms} sparc-solaris-gcc"
 all_platforms="${all_platforms} x86-android-gcc"
 all_platforms="${all_platforms} x86-darwin8-gcc"
@@ -251,6 +252,7 @@ ARCH_LIST="
     x86_64
     ppc
     loongarch
+    riscv64
 "
 ARCH_EXT_LIST_X86="
     mmx

--- a/test/test.mk
+++ b/test/test.mk
@@ -13,6 +13,15 @@ LIBVPX_TEST_SRCS-yes += test_vectors.h
 LIBVPX_TEST_SRCS-yes += util.h
 LIBVPX_TEST_SRCS-yes += video_source.h
 
+## FOR RISCV64
+## 
+## Test entry for riscv64 cpu and vector processor
+ifeq ($(VPX_ARCH_RISCV64), yes)
+    LIBVPX_TEST_SRCS-yes += test_rvv.cc
+endif
+
+
+
 ##
 ## BLACK BOX TESTS
 ##

--- a/test/test_rvv.cc
+++ b/test/test_rvv.cc
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include "third_party/googletest/src/include/gtest/gtest.h"
+
+TEST(HelloRiscv, PrintHelloRiscv) {
+    printf("Hello, Riscv!");
+}


### PR DESCRIPTION
Test requirements:

riscv-gnu-toolchain,
https://github.com/riscv-collab/riscv-gnu-toolchain/releases/tag/2023.06.09
./configure --prefix=/path/to/install/riscv-gnu-toolchain --with-arch=rv64gcv --with-abi=lp64d

Qemu 7.2+
git checkout remotes/origin/staging-7.2
./configure  --enable-kvm --enable-system --enable-sdl --enable-opengl --target-list="riscv64-softmmu,riscv64-linux-user" 

gcc13+
git checkout releases/gcc-13.1.0

Test steps :
export LIBVPX=/root/path/to/libvpx
export RISCV=/path/to/install/riscv-gnu-toolchain

cd $LIBVPX
mkdir  buildv
cd buildv
CROSS=riscv64-unknown-linux-gnu- ../configure --target=riscv64-unknown-linux-gnu-gcc --disable-examples --disable-tools --disable-docs --enable-runtime-cpu-detect
make 
qemu-riscv64 -cpu rv64,v=true,vlen=256,vext_spec=v1.0 -L $RISCV/sysroot test_libvpx --gtest_filter='*HelloRiscv*'

