### PR TITLE
Add riscv64 support

### DIFF
--- a/configure
+++ b/configure
@@ -126,6 +126,7 @@ all_platforms="${all_platforms} loongarch64-linux-gcc"
 all_platforms="${all_platforms} mips32-linux-gcc"
 all_platforms="${all_platforms} mips64-linux-gcc"
 all_platforms="${all_platforms} ppc64le-linux-gcc"
+all_platforms="${all_platforms} riscv64-linux-gcc"
 all_platforms="${all_platforms} sparc-solaris-gcc"
 all_platforms="${all_platforms} x86-android-gcc"
 all_platforms="${all_platforms} x86-darwin8-gcc"
@@ -251,6 +252,7 @@ ARCH_LIST="
     x86_64
     ppc
     loongarch
+    riscv64
 "
 ARCH_EXT_LIST_X86="
     mmx


### PR DESCRIPTION
测试要求:

Host OS 建议是 较新版本的 Ubuntu，我的是Ubuntu 18.04.

1. 安装交叉编译器

```
sudo apt install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu cpp-riscv64-linux-gnu
mkdir build
cd build
CROSS=riscv64-linux-gnu- ../configure --target=riscv64-linux-gcc --enable-unit-tests
make -j16
```

2. 编译 riscv-gnu-toolchain
```
git clone git@github.com:riscv-collab/riscv-gnu-toolchain.git
cd riscv-gnu-toolchain
mkdir build
cd build 
export RISCV=/home/sunmin/bins/riscv-gnu-toolchain-bin-rvv
../configure --prefix=$RISCV --with-arch=rv64gcv --with-abi=lp64d
make linux -j28
```

3. 编译 qemu 
```
git clone https://github.com/qemu/qemu
cd qemu
git checkout remotes/origin/staging-7.2

./configure  --enable-kvm --enable-system --enable-sdl --enable-opengl --target-list="riscv64-softmmu,riscv64-linux-user"
make -j28

#设定 qemu 环境变量
export PATH=/home/sunmin/aosp-out/qemu/qemu/build:$PATH

sunmin@plct:~/rvv/libvpx/build-riscv64$ which qemu-riscv64
/home/sunmin/aosp-out/qemu/qemu/build/qemu-riscv64

sunmin@t5820:~/aosp-out/qemu/qemu$ qemu-riscv64 --version
qemu-riscv64 version 7.2.3 (v7.2.3)
Copyright (c) 2003-2022 Fabrice Bellard and the QEMU Project developers
```

5. 在 qemu 虚拟环境中运行 libvpx 自带的测试程序
```
qemu-riscv64 -cpu rv64 -L $RISCV/sysroot ./test_libvpx
[==========] Running 10187 tests from 141 test suites.
[----------] Global test environment set-up.
[----------] 1 test from ByteAlignmentTest
[ RUN      ] ByteAlignmentTest.SwitchByteAlignment
../test/webm_video_source.h:43: Failure
Expected: (vpx_ctx_->file) != (nullptr), actual: NULL vs (nullptr)
Input file open failed. Filename: vp90-2-02-size-lf-1920x1080.webm
../test/byte_alignment_test.cc:132: Failure
```

Close issue  #2 