### PR TITLE
 add rvv vpx_comp_avg_pred

### DIFF
--- a/test/comp_avg_pred_test.cc
+++ b/test/comp_avg_pred_test.cc
@@ -227,6 +227,11 @@ INSTANTIATE_TEST_SUITE_P(NEON, AvgPredTestLBD,
                          ::testing::Values(&vpx_comp_avg_pred_neon));
 #endif  // HAVE_NEON
 
+#if HAVE_RVV
+INSTANTIATE_TEST_SUITE_P(RVV, AvgPredTestLBD,
+                         ::testing::Values(&vpx_comp_avg_pred_rvv));
+#endif  // HAVE_RVV
+
 #if HAVE_VSX
 INSTANTIATE_TEST_SUITE_P(VSX, AvgPredTestLBD,
                          ::testing::Values(&vpx_comp_avg_pred_vsx));

--- a/vp8/common/riscv/copymem_rvv.c
+++ b/vp8/common/riscv/copymem_rvv.c
@@ -1,0 +1,54 @@
+#include <riscv_vector.h>
+#include "./vpx_config.h"
+#include "./vp8_rtcd.h"
+
+void vp8_copy_mem16x16_rvv(unsigned char *src, int src_stride,
+                           unsigned char *dst, int dst_stride) {
+  vuint64m2_t v;
+  size_t vl;
+  size_t n = 16;
+  while (n) {
+    /* Assume e64 is supported. */
+    vl = __riscv_vsetvl_e64m2(n);
+
+    v = __riscv_vlse64_v_u64m2((uint64_t *) src, src_stride, vl);
+    __riscv_vsse64_v_u64m2((uint64_t *) dst, dst_stride, v, vl);
+
+    v = __riscv_vlse64_v_u64m2((uint64_t *) (src + 8), src_stride, vl);
+    __riscv_vsse64_v_u64m2((uint64_t *) (dst + 8), dst_stride, v, vl);
+
+    n -= vl;
+    src += src_stride * vl;
+    dst += dst_stride * vl;
+  }
+}
+
+void vp8_copy_mem8x8_rvv(unsigned char *src, int src_stride,
+                         unsigned char *dst, int dst_stride) {
+  size_t n = 8;
+  size_t vl;
+  vuint64m2_t v;
+
+  while (n) {
+    /* Assume e64 is supported. */
+    vl = __riscv_vsetvl_e64m2(n);
+
+    v = __riscv_vlse64_v_u64m2((uint64_t *) src, src_stride, vl);
+    __riscv_vsse64_v_u64m2((uint64_t *) dst, dst_stride, v, vl);
+
+    n -= vl;
+    src += src_stride * vl;
+    dst += dst_stride * vl;
+  }
+}
+
+void vp8_copy_mem8x4_rvv(unsigned char *src, int src_stride,
+                         unsigned char *dst, int dst_stride) {
+  size_t vl;
+  vuint64m2_t v;
+
+  /* VL must be 4 because VLEN must be >= 128. Assume e64 is supported. */
+  vl = __riscv_vsetvl_e64m2(4);
+  v = __riscv_vlse64_v_u64m2((uint64_t *) src, src_stride, vl);
+  __riscv_vsse64_v_u64m2((uint64_t *) dst, dst_stride, v, vl);
+}

--- a/vp8/common/rtcd_defs.pl
+++ b/vp8/common/rtcd_defs.pl
@@ -114,13 +114,13 @@ specialize qw/vp8_dc_only_idct_add mmx neon dspr2 msa mmi lsx/;
 # RECON
 #
 add_proto qw/void vp8_copy_mem16x16/, "unsigned char *src, int src_stride, unsigned char *dst, int dst_stride";
-specialize qw/vp8_copy_mem16x16 sse2 neon dspr2 msa mmi/;
+specialize qw/vp8_copy_mem16x16 sse2 neon dspr2 msa mmi rvv/;
 
 add_proto qw/void vp8_copy_mem8x8/, "unsigned char *src, int src_stride, unsigned char *dst, int dst_stride";
-specialize qw/vp8_copy_mem8x8 mmx neon dspr2 msa mmi/;
+specialize qw/vp8_copy_mem8x8 mmx neon dspr2 msa mmi rvv/;
 
 add_proto qw/void vp8_copy_mem8x4/, "unsigned char *src, int src_stride, unsigned char *dst, int dst_stride";
-specialize qw/vp8_copy_mem8x4 mmx neon dspr2 msa mmi/;
+specialize qw/vp8_copy_mem8x4 mmx neon dspr2 msa mmi rvv/;
 
 #
 # Postproc

--- a/vp8/vp8_common.mk
+++ b/vp8/vp8_common.mk
@@ -148,5 +148,6 @@ VP8_COMMON_SRCS-$(HAVE_NEON)  += common/arm/neon/sixtappredict_neon.c
 
 # common (rvv intrinsics)
 VP8_COMMON_SRCS-$(HAVE_RVV) += common/riscv/sixtap_predict_rvv.c
+VP8_COMMON_SRCS-$(HAVE_RVV) += common/riscv/copymem_rvv.c
 
 $(eval $(call rtcd_h_template,vp8_rtcd,vp8/common/rtcd_defs.pl))

--- a/vpx_dsp/riscv/avg_pred_rvv.c
+++ b/vpx_dsp/riscv/avg_pred_rvv.c
@@ -1,0 +1,98 @@
+#include <assert.h>
+#include "./vpx_dsp_rtcd.h"
+#include <riscv_vector.h>
+
+/***
+ * This function appends contents of b[] to the end of a[].
+ * a[] is of size m+n and b[] is of size n. 
+*/
+void concat(uint8_t a[], uint8_t b[], int m, int n)
+{
+  memcpy(a + m, b, sizeof(b));
+}
+
+/***
+ * This function computes the value of  (va + vb) / 2
+*/
+vuint8m1_t average_add(const vuint8m1_t va, const vuint8m1_t vb, const size_t vl){
+  vuint16m2_t vavg = __riscv_vwaddu_vv_u16m2(va, vb, vl);
+  vavg = __riscv_vadd_vx_u16m2(vavg, 1, vl);
+  return __riscv_vnsrl_wx_u8m1 (vavg, 1, vl);
+}
+
+void vpx_comp_avg_pred_rvv(uint8_t *comp_pred, const uint8_t *pred, int width,
+                         int height, const uint8_t *ref, int ref_stride) {
+  if (width > 8){
+    int x, y = height;
+    const size_t vl = 16;
+    vuint8m1_t vr, vavg;
+    do {
+      for (x = 0; x < width; x += 16) {
+        const vuint8m1_t vp = __riscv_vle8_v_u8m1(pred + x, vl);
+        vr = __riscv_vle8_v_u8m1(ref + x, vl);
+        vr = average_add(vp, vr, vl);
+        __riscv_vse8_v_u8m1(comp_pred + x, vr, vl);
+      }
+      comp_pred += width;
+      pred += width;
+      ref += ref_stride;
+    } while (--y);
+  } else if (width == 8) {
+    int i = width * height;
+    const size_t vl = 16;
+    vuint8m1_t vr;
+    vuint8m1_t vr_0, vr_1, vv;
+    uint8_t a[16] = {0};
+    uint8_t b[8] = {0};
+    do {
+      const vuint8m1_t vp = __riscv_vle8_v_u8m1(pred, vl);
+      vr_0 = __riscv_vle8_v_u8m1(ref, vl / 2);
+      __riscv_vse8_v_u8m1(a, vr_0, vl / 2);
+      vr_1 = __riscv_vle8_v_u8m1(ref + ref_stride, vl / 2);
+      __riscv_vse8_v_u8m1(b, vr_1, vl / 2);
+      concat(a, b, 8, 8);
+      vr = __riscv_vle8_v_u8m1(a, vl);
+      vr = average_add(vp, vr, vl);
+      ref += 2 * ref_stride;
+      __riscv_vse8_v_u8m1(comp_pred, vr, vl);
+
+      pred += 16;
+      comp_pred += 16;
+      i -= 16;
+      } while (i);
+  } else {
+    int i = width * height;
+    assert(width == 4);
+    const size_t vl = 16;
+    vuint8m1_t vr;
+    if (width == ref_stride) {
+      do {
+        const vuint8m1_t vp  = __riscv_vle8_v_u8m1(pred, vl);
+        vr = __riscv_vle8_v_u8m1(ref, vl);
+        ref += 4 * ref_stride;
+        vr = average_add(vp, vr, vl);
+        __riscv_vse8_v_u8m1(comp_pred, vr, vl);
+
+        pred += 16;
+        comp_pred += 16;
+        i -= 16; 
+      } while (i);
+    } else {
+      do {
+        uint32_t a;
+        vuint32m1_t a_u32;
+
+        const vuint8m1_t vp  = __riscv_vle8_v_u8m1(pred, vl);
+        a_u32 = __riscv_vlse32_v_u32m1(ref, ref_stride, vl / 4);
+        vuint8m1_t vr = __riscv_vreinterpret_v_u32m1_u8m1(a_u32);
+        ref += 4 * ref_stride;
+        vr = average_add(vp, vr, vl);        
+        __riscv_vse8_v_u8m1(comp_pred, vr, vl);
+
+        pred += 16;
+        comp_pred += 16;
+        i -= 16;  
+      } while (i);
+    }
+  }
+}

--- a/vpx_dsp/vpx_dsp.mk
+++ b/vpx_dsp/vpx_dsp.mk
@@ -421,6 +421,9 @@ DSP_SRCS-$(HAVE_LSX)    += loongarch/variance_lsx.c
 DSP_SRCS-$(HAVE_LSX)    += loongarch/sub_pixel_variance_lsx.c
 DSP_SRCS-$(HAVE_LSX)    += loongarch/avg_pred_lsx.c
 
+DSP_SRCS-$(HAVE_RVV)    += riscv/avg_pred_rvv.c
+
+
 DSP_SRCS-$(HAVE_MMI)    += mips/variance_mmi.c
 
 DSP_SRCS-$(HAVE_SSE2)   += x86/avg_pred_sse2.c

--- a/vpx_dsp/vpx_dsp_rtcd_defs.pl
+++ b/vpx_dsp/vpx_dsp_rtcd_defs.pl
@@ -1321,7 +1321,7 @@ add_proto qw/unsigned int vpx_get4x4sse_cs/, "const unsigned char *src_ptr, int 
   specialize qw/vpx_get4x4sse_cs neon msa vsx/;
 
 add_proto qw/void vpx_comp_avg_pred/, "uint8_t *comp_pred, const uint8_t *pred, int width, int height, const uint8_t *ref, int ref_stride";
-  specialize qw/vpx_comp_avg_pred neon sse2 avx2 vsx lsx/;
+  specialize qw/vpx_comp_avg_pred neon rvv sse2 avx2 vsx lsx/;
 
 #
 # Subpixel Variance


### PR DESCRIPTION
 The optimization logic is taken from corresponding neon code
 Test entry was added to comp_avg_pred_test.cc

Test methods:

1.compile
CROSS=/home/summer/nvme/bins/gnu-toolchain-bins-rvv-1.0/bin/riscv64-unknown-linux-gnu- ../configure --target=riscv64-linux-gcc --enable-unit-tests --enable-debug --disable-optimizations

2. run
qemu-riscv64 -cpu rv64,v=true,vlen=1024,vext_spec=v1.0 -L $RISCV/sysroot ./test_libvpx --gtest_filter='RVV/AvgPredTestLBD*'

3.debug
qemu-riscv64 -cpu rv64,v=true,vlen=1024,vext_spec=v1.0 -g 1234 -L $RISCV/sysroot ./test_libvpx --gtest_filter='RVV/AvgPredTestLBD*'

riscv64-unknown-linux-gnu-gdb ./test_libvpx -ex "target remote localhost:1234"
