### PR TITLE
RISC-V: Header file inclusion

### DIFF
--- a/vpx_ports/riscv.h
+++ b/vpx_ports/riscv.h
@@ -11,6 +11,10 @@
 #ifndef VPX_VPX_PORTS_RISCV_H_
 #define VPX_VPX_PORTS_RISCV_H_
 
+#ifdef __riscv_v_intrinsic
+#include <riscv_vector.h>
+#endif/* __riscv_v_intrinsic */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -24,3 +28,4 @@ int riscv_cpu_caps(void);
 #endif
 
 #endif  // VPX_VPX_PORTS_RISCV_H_
+


### PR DESCRIPTION
    To leverage the intrinsics in the compiler, the header <riscv_vector.h> needs to be included.

    This commit contains the recommended inclusion from rvv-intrinsic draft doc:
    https://github.com/riscv-non-isa/rvv-intrinsic-doc/releases/tag/draft-20230811-a810011071e9e2f630450f01f5fdc9a9ccc3e3be

    Please refer to: Chapter 3. Header file inclusion.

    Usage:

    Please add the below code
    #include <vpx_ports/riscv.h>
    to the top of rvv-intrinsic source file.