### PR TITLE
[rvv]: guard inclusion with the test macro

### DIFF
--- a/vp8/common/riscv/copymem_rvv.c
+++ b/vp8/common/riscv/copymem_rvv.c
@@ -1,4 +1,7 @@
+#ifdef __riscv_v_intrinsic
 #include <riscv_vector.h>
+#endif /* __riscv_v_intrinsic */
+
 #include "./vpx_config.h"
 #include "./vp8_rtcd.h"
 

--- a/vp8/common/riscv/sixtap_predict_rvv.c
+++ b/vp8/common/riscv/sixtap_predict_rvv.c
@@ -1,4 +1,7 @@
+#ifdef __riscv_v_intrinsic
 #include <riscv_vector.h>
+#endif /* __riscv_v_intrinsic */
+
 #include <stdio.h>
 #include "./vpx_config.h"
 #include "./vp8_rtcd.h"


### PR DESCRIPTION
As suggested by lastest rvv spec
(draft-20230811-a810011071e9e2f630450f01f5fdc9a9ccc3e3be) Chapter 3. Header file inclusion

> To leverage the intrinsics in the compiler,
> the header <riscv_vector.h> needs to be included. We
> suggest the inclusion to be guarded with the test macro
> of the intrinsics.