### PR TITLE
RISC-V: Add vpx_comp_avg_pred_rvv

### DIFF
--- a/test/comp_avg_pred_test.cc
+++ b/test/comp_avg_pred_test.cc
@@ -227,6 +227,11 @@ INSTANTIATE_TEST_SUITE_P(NEON, AvgPredTestLBD,
                          ::testing::Values(&vpx_comp_avg_pred_neon));
 #endif  // HAVE_NEON
 
+#if HAVE_RVV
+INSTANTIATE_TEST_SUITE_P(RVV, AvgPredTestLBD,
+                         ::testing::Values(&vpx_comp_avg_pred_rvv));
+#endif  // HAVE_RVV
+
 #if HAVE_VSX
 INSTANTIATE_TEST_SUITE_P(VSX, AvgPredTestLBD,
                          ::testing::Values(&vpx_comp_avg_pred_vsx));

--- a/vpx_dsp/riscv/avg_pred_rvv.c
+++ b/vpx_dsp/riscv/avg_pred_rvv.c
@@ -1,0 +1,72 @@
+#include <assert.h>
+#include "./vpx_dsp_rtcd.h"
+#include <riscv_vector.h>
+#include <stdlib.h>
+#include <string.h>
+
+void vpx_comp_avg_pred_rvv(uint8_t *comp_pred, const uint8_t *pred, int width,
+                         int height, const uint8_t *ref, int ref_stride) {
+                          
+  const size_t avl = 16;
+  size_t vl;
+  if (width > 8){
+    int x, y = height;
+    vuint8m8_t vr, vp;
+    do {
+      for (x = 0; x < width; x += vl){
+        vl =  __riscv_vsetvl_e8m8(width - x);
+        vp = __riscv_vle8_v_u8m8(pred + x, vl);
+        vr = __riscv_vle8_v_u8m8(ref + x, vl);
+        vr = __riscv_vaaddu_vv_u8m8(vp, vr, __RISCV_VXRM_RNU, vl);
+        __riscv_vse8_v_u8m8(comp_pred + x, vr, vl);
+      }
+      comp_pred += width;
+      pred += width;
+      ref += ref_stride;
+    } while (--y);
+  } else if (width == 8) {
+    int i = width * height;
+    size_t k;
+    uint8_t *index;
+    vuint8m1_t vr, vp, vindex;
+    do {
+      vl = __riscv_vsetvl_e8m1(avl);
+      index = (uint8_t *)malloc(vl * sizeof(uint8_t));
+      memset(index, 0, vl);
+      vp = __riscv_vle8_v_u8m1(pred, vl);
+      for(k = 0; k < vl; k++){
+        if(k < vl / 2){
+          index[k] = (uint8_t)k;
+        }else{
+          index[k] = (uint8_t)(ref_stride + k - 8);
+        }
+      }
+      vindex = __riscv_vle8_v_u8m1(index, vl);
+      vr =  __riscv_vloxei8_v_u8m1(ref, vindex, vl);
+      vr = __riscv_vaaddu_vv_u8m1(vp, vr, __RISCV_VXRM_RNU, vl);
+      __riscv_vse8_v_u8m1(comp_pred, vr, vl);
+      ref += 2 * ref_stride;
+      pred += vl;
+      comp_pred += vl;
+      i -= vl;
+      } while (i);
+  } else {
+    int i = width * height;
+    vuint8m1_t vr, vp;
+    vuint32m1_t a_u32;
+    assert(width == 4);
+    vl = __riscv_vsetvl_e8m1(avl);
+    do {
+      vp  = __riscv_vle8_v_u8m1(pred, vl);
+      a_u32 = __riscv_vlse32_v_u32m1((const uint32_t*)ref, ref_stride, vl / 4);
+      vr = __riscv_vreinterpret_v_u32m1_u8m1(a_u32);
+      ref += 4 * ref_stride;
+      vr = __riscv_vaaddu_vv_u8m1(vp, vr, __RISCV_VXRM_RNU, vl);  
+      __riscv_vse8_v_u8m1(comp_pred, vr, vl);
+
+      pred += vl;
+      comp_pred += vl;
+      i -= vl;  
+    } while (i);
+  }
+}

--- a/vpx_dsp/vpx_dsp.mk
+++ b/vpx_dsp/vpx_dsp.mk
@@ -413,6 +413,8 @@ DSP_SRCS-$(HAVE_NEON)   += arm/avg_pred_neon.c
 DSP_SRCS-$(HAVE_NEON)   += arm/subpel_variance_neon.c
 DSP_SRCS-$(HAVE_NEON)   += arm/variance_neon.c
 
+DSP_SRCS-$(HAVE_RVV)   += riscv/avg_pred_rvv.c
+
 DSP_SRCS-$(HAVE_MSA)    += mips/variance_msa.c
 DSP_SRCS-$(HAVE_MSA)    += mips/sub_pixel_variance_msa.c
 

--- a/vpx_dsp/vpx_dsp_rtcd_defs.pl
+++ b/vpx_dsp/vpx_dsp_rtcd_defs.pl
@@ -1321,7 +1321,7 @@ add_proto qw/unsigned int vpx_get4x4sse_cs/, "const unsigned char *src_ptr, int 
   specialize qw/vpx_get4x4sse_cs neon msa vsx/;
 
 add_proto qw/void vpx_comp_avg_pred/, "uint8_t *comp_pred, const uint8_t *pred, int width, int height, const uint8_t *ref, int ref_stride";
-  specialize qw/vpx_comp_avg_pred neon sse2 avx2 vsx lsx/;
+  specialize qw/vpx_comp_avg_pred neon sse2 avx2 vsx lsx rvv/;
 
 #
 # Subpixel Variance


### PR DESCRIPTION
测试平台 D1 Nezha 
```
root@TinaLinux:/# uname -a
Linux TinaLinux 5.4.61 #11 PREEMPT Mon Aug 28 11:36:07 UTC 2023 riscv64 GNU/Linux
root@TinaLinux:/# cat /proc/cpuinfo
processor       : 0
hart            : 0
isa             : rv64imafdcvu
mmu             : sv39
```


查阅c906用户手册
https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//1685946574371/%E7%8E%84%E9%93%81C906R2S1%E7%94%A8%E6%88%B7%E6%89%8B%E5%86%8C%EF%BC%88occ%EF%BC%89.pdf

指令名称  指令描述   执行延时（LMUL=1）
VSADD.VV         矢量整型加法有符号取饱和指令        3
VAADD.VV        矢量整型加法取平均数指令                3

推测vsaddu和vaaddu两个函数耗时情况接近.


为了比对优化前后的性能，我们把 rvv1.0 的 intrinsic 代码改写成 rvv 0.7.1, 然后在现有的硬件平台（D1 Nezha）测试，
由于 D1 不支持vaaddu（Vector Single-Width Averaging Add）我们把它替换成 vsaddu（Vector Single-Width Saturating Add）


工具链及编译参数

```
~/bins/Xuantie-900-gcc-elf-newlib-x86_64-V2.2.4/bin/riscv64-unknown-elf-gcc -march=rv64gcv0p7_zfh_xtheadc -O3 test.c -o test
```
参考
https://github.com/sipeed/TinyMaix/blob/9487854be2ce329b89427d4a5b14ce6136cb15cf/src/arch_rv64v.h#L24


把测试程序推送到开发板，然后记录 10000000 次循环耗时

```
D:\bins\> adb devices
List of devices attached
20080411        device
adb push test /tmp; adb shell chmod +x /tmp/test ; adb shell time /tmp/test

width > 8
// vpx_comp_avg_pred_rvv(dst,src,20,40,ref,8);// 20.12s
// vpx_comp_avg_pred_c(dst,src,20,40,ref,8);//1m 16.88s

width = 8
// vpx_comp_avg_pred_rvv(dst,src,8,40,ref,8);//14.49s
// vpx_comp_avg_pred_c(dst,src,8,40,ref,8);// 21.37s

width = 4
// vpx_comp_avg_pred_rvv(dst,src,4,40,ref,8);// 3.38s
// vpx_comp_avg_pred_c(dst,src,4,40,ref,8);// 2.45s 
```


test.c 如下

```
//#include <assert.h>
//#include "./vpx_dsp_rtcd.h"
//#include <vpx_ports/riscv.h>
#include <time.h>
#include <stdlib.h>
#include <stdio.h>
#include <string.h>
#include <riscv_vector.h>
void vpx_comp_avg_pred_rvv(uint8_t *comp_pred, const uint8_t *pred, int width,
                         int height, const uint8_t *ref, int ref_stride) {
  const size_t avl = 16;
  size_t vl;
  if (width > 8){
    int x, y = height;
    vuint8m8_t vr;
    do {
      for (x = 0; x < width; x += vl){
        vl =   vsetvl_e8m8(width - x);
        const vuint8m8_t vp =  vle8_v_u8m8(pred + x, vl);
        vr =  vle8_v_u8m8(ref + x, vl);
        //D1 not support vaaddu
        // vr =  vaaddu_vv_u8m1(vp, vr, vl);  
        vr =  vsaddu_vv_u8m8(vp, vr,vl);
        vse8_v_u8m8(comp_pred + x, vr, vl);
      }
      comp_pred += width;
      pred += width;
      ref += ref_stride;
    } while (--y);
  } else if (width == 8) {
    int i = width * height;
    size_t k;
    uint8_t *index;
    vuint8m1_t vr;
    do {
      vl =  vsetvl_e8m1(avl);
      const vuint8m1_t vp =  vle8_v_u8m1(pred, vl);
      index = (uint8_t *)malloc(vl * sizeof(uint8_t));
      memset(index, 0, vl);
      for(k = 0; k < vl; k++){
        if(k < vl / 2){
            index[k] = (uint8_t)k;
          }else{
            index[k] = (uint8_t)(ref_stride + k - 8);
          }
      }
      vuint8m1_t vindex =  vle8_v_u8m1(index, vl);
      vr =   vloxei8_v_u8m1(ref, vindex, vl);
      //D1 not support vaaddu
      // vr =  vaaddu_vv_u8m1(vp, vr, vl);  
      vr =  vsaddu_vv_u8m1(vp, vr, vl);
      vse8_v_u8m1(comp_pred, vr, vl);
      ref += 2 * ref_stride;
      pred += vl;
      comp_pred += vl;
      i -= vl;
      } while (i);
  } else {
    int i = width * height;
    //assert(width == 4);
    vuint8m1_t vr;
    vl =  vsetvl_e8m1(avl);
    do {
      vuint32m1_t a_u32;
      const vuint8m1_t vp  =  vle8_v_u8m1(pred, vl);
      a_u32 =  vlse32_v_u32m1((const uint32_t*)ref, ref_stride, vl / 4);
      vr =  vreinterpret_v_u32m1_u8m1(a_u32);
      ref += 4 * ref_stride;

      //D1 not support vaaddu
      // vr =  vaaddu_vv_u8m1(vp, vr, vl);  
      vr =  vsaddu_vv_u8m1(vp, vr, vl);  
      vse8_v_u8m1(comp_pred, vr, vl);

      pred += vl;
      comp_pred += vl;
      i -= vl;  
    } while (i);
    }
}

/* Shift down with rounding */
#define ROUND_POWER_OF_TWO(value, n) (((value) + (1 << ((n)-1))) >> (n))

void vpx_comp_avg_pred_c(uint8_t *comp_pred, const uint8_t *pred, int width,
                         int height, const uint8_t *ref, int ref_stride) {
  int i, j;
  for (i = 0; i < height; ++i) {
    for (j = 0; j < width; ++j) {
      const int tmp = pred[j] + ref[j];
      comp_pred[j] = ROUND_POWER_OF_TWO(tmp, 1);
    }
    comp_pred += width;
    pred += width;
    ref += ref_stride;
  }
}
uint8_t* getDataUint8(const int len){
    uint8_t* data = (uint8_t *)malloc(len * sizeof(uint8_t));
    for(int i = 0 ; i < len; i++){
    	data[i] = (uint8_t) (i + 1);
    }
    return data;
}

int main() {

  int w=200,h=200;
    uint8_t *src = getDataUint8(w*h),*dst = getDataUint8(w*h);
    uint8_t *ref = getDataUint8(w*h);
    int stride = 7;
    int loops = 10000000;

    time_t start,end;
    time (&start);

    for(int i = 0;i< loops;i++){
        // vpx_comp_avg_pred_rvv(dst,src,20,40,ref,8);// 20.12s
        // vpx_comp_avg_pred_c(dst,src,20,40,ref,8);//1m 16.88s

        // vpx_comp_avg_pred_rvv(dst,src,8,40,ref,8);//14.49s
        // vpx_comp_avg_pred_c(dst,src,8,40,ref,8);// 21.37s

        vpx_comp_avg_pred_rvv(dst,src,4,40,ref,8);// 3.38s
        // vpx_comp_avg_pred_c(dst,src,4,40,ref,8);// 2.45s 

        // vpx_comp_avg_pred_rvv(dst,src,8,40,ref,24);//19.09s

          // vpx_comp_avg_pred_rvv(dst,src,20,40,ref,24);// 20.13s
        // vpx_comp_avg_pred_c(dst,src,20,40,ref,24);// 20.13s

        // vpx_comp_avg_pred_rvv(dst,src,4,40,ref,24);// 3.39s

    }

  time (&end);
  double dif = difftime (end,start);
  printf ("Elasped time is %.2lf seconds.\n", dif);
  return 0;
}
```

